### PR TITLE
feat: add first time tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Created specifically for homeschool families and educators in Virginia, this too
 * **Share progress data** between parents/teachers through the import/export feature.
 * **Focus your teaching efforts** by identifying standards that need additional attention.
 * **No account registration or cloud storage required** - all data is stored locally on your device with options to export for backup or sharing between devices.
+* **Gentle first-time tour** explains how everything works and can be reopened from the settings gear.
 
 ## Why Use Virginia SOL Explorer?
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import SettingsFlyout from "./components/SettingsFlyout";
 import { ProfileProvider, useProfile } from "./context/ProfileContext";
 import ProfileSummaryCard from "./components/ProfileSummaryCard";
 import { StandardMasteryProvider } from "./context/StandardMasteryContext";
+import FirstTimeExperience from "./components/FirstTimeExperience";
 
 const getVisibilityStatusFromStorage = () => {
   const storedHideCompleted = localStorage.getItem("hideCompleted");
@@ -31,6 +32,25 @@ const AppContent: React.FC = () => {
   const [hideCompleted, setHideCompleted] = useState(
     getVisibilityStatusFromStorage()
   );
+  const [showIntro, setShowIntro] = useState(false);
+
+  const INTRO_COOKIE = "vsol_intro_dismissed";
+
+  const hasSeenIntro = () =>
+    document.cookie
+      .split("; ")
+      .some((row) => row.startsWith(`${INTRO_COOKIE}=true`));
+
+  useEffect(() => {
+    if (!hasSeenIntro()) {
+      setShowIntro(true);
+    }
+  }, []);
+
+  const handleIntroClose = () => {
+    document.cookie = `${INTRO_COOKIE}=true; max-age=31536000; path=/`;
+    setShowIntro(false);
+  };
 
   const subjects = [
     ...new Set(standardsData.map((standard) => standard.subject)),
@@ -125,6 +145,7 @@ const AppContent: React.FC = () => {
             <SettingsFlyout
               hideCompleted={hideCompleted}
               setHideCompleted={setHideCompleted}
+              openIntro={() => setShowIntro(true)}
             />
           </div>
         </div>
@@ -156,6 +177,8 @@ const AppContent: React.FC = () => {
           GitHub
         </a>
       </div>
+
+      <FirstTimeExperience isOpen={showIntro} onClose={handleIntroClose} />
     </div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ const AppContent: React.FC = () => {
   );
   const [showIntro, setShowIntro] = useState(false);
   const settingsButtonRef = useRef<HTMLButtonElement>(null);
+  const profileCardRef = useRef<HTMLDivElement>(null);
 
   const INTRO_COOKIE = "vsol_intro_dismissed";
 
@@ -138,7 +139,10 @@ const AppContent: React.FC = () => {
 
           {/* Middle: Profile Card */}
           <div className="grow order-3">
-            <ProfileSummaryCard filteredStandards={filteredSubjectStandards} />
+            <ProfileSummaryCard
+              ref={profileCardRef}
+              filteredStandards={filteredSubjectStandards}
+            />
           </div>
 
           {/* Right: Settings */}
@@ -184,6 +188,7 @@ const AppContent: React.FC = () => {
         isOpen={showIntro}
         onClose={handleIntroClose}
         settingsButtonRef={settingsButtonRef}
+        profileCardRef={profileCardRef}
       />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 // App.tsx
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { SubjectStandard } from "./types";
 import useStandardsData from "./hooks/useStandardsData";
 import TwoPaneSubjectStandardDisplay from "./TwoPaneSubjectStandardDisplay";
@@ -33,6 +33,7 @@ const AppContent: React.FC = () => {
     getVisibilityStatusFromStorage()
   );
   const [showIntro, setShowIntro] = useState(false);
+  const settingsButtonRef = useRef<HTMLButtonElement>(null);
 
   const INTRO_COOKIE = "vsol_intro_dismissed";
 
@@ -146,6 +147,7 @@ const AppContent: React.FC = () => {
               hideCompleted={hideCompleted}
               setHideCompleted={setHideCompleted}
               openIntro={() => setShowIntro(true)}
+              gearRef={settingsButtonRef}
             />
           </div>
         </div>
@@ -178,7 +180,11 @@ const AppContent: React.FC = () => {
         </a>
       </div>
 
-      <FirstTimeExperience isOpen={showIntro} onClose={handleIntroClose} />
+      <FirstTimeExperience
+        isOpen={showIntro}
+        onClose={handleIntroClose}
+        settingsButtonRef={settingsButtonRef}
+      />
     </div>
   );
 };

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -1,4 +1,10 @@
-import React, { Fragment, useState, useEffect, useRef } from "react";
+import React, {
+  Fragment,
+  useState,
+  useEffect,
+  useRef,
+  useLayoutEffect,
+} from "react";
 import { Dialog, Transition } from "@headlessui/react";
 
 interface FirstTimeExperienceProps {
@@ -50,8 +56,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
       setStep(0);
     }
   }, [isOpen]);
-
-  useEffect(() => {
+  useLayoutEffect(() => {
     const gear = settingsButtonRef.current;
     const card = profileCardRef.current;
     const overlay = overlayRef.current;
@@ -63,9 +68,8 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
     gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
     card?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
 
-    const fade = 120; // width of the gradient fade
-
     if (step === 3 && gear) {
+      const fade = 120; // width of the gradient fade
       const rect = gear.getBoundingClientRect();
       const r = Math.max(rect.width, rect.height) * 1.5;
       const x = rect.left + rect.width / 2;
@@ -75,6 +79,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
         rgba(0,0,0,0.5) ${r + fade}px)`;
       gear.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
     } else if (step === 4 && card) {
+      const fade = 60; // narrower fade for smaller spotlight
       const rect = card.getBoundingClientRect();
       const r = Math.hypot(rect.width, rect.height) / 2;
       const x = rect.left + rect.width / 2;
@@ -84,6 +89,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
         rgba(0,0,0,0.5) ${r + fade}px)`;
       card.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
     } else if (panel) {
+      const fade = 120;
       const rect = panel.getBoundingClientRect();
       const x = rect.left + rect.width / 2;
       const y = rect.top + rect.height / 2;

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -57,53 +57,64 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
     }
   }, [isOpen]);
   useLayoutEffect(() => {
-    const gear = settingsButtonRef.current;
-    const card = profileCardRef.current;
-    const overlay = overlayRef.current;
-    const panel = panelRef.current;
-    if (!overlay) return;
+    let frame: number;
+    let gearEl: HTMLButtonElement | null = null;
+    let cardEl: HTMLDivElement | null = null;
+    let overlayEl: HTMLDivElement | null = null;
+    const updateHighlight = () => {
+      gearEl = settingsButtonRef.current;
+      cardEl = profileCardRef.current;
+      overlayEl = overlayRef.current;
+      const panel = panelRef.current;
+      if (!overlayEl || !panel) {
+        frame = requestAnimationFrame(updateHighlight);
+        return;
+      }
 
-    // Reset any previous highlighting
-    overlay.style.background = "";
-    gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
-    card?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+      // Reset any previous highlighting
+      overlayEl.style.background = "";
+      gearEl?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+      cardEl?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
 
-    if (step === 3 && gear) {
-      const fade = 120; // width of the gradient fade
-      const rect = gear.getBoundingClientRect();
-      const r = Math.max(rect.width, rect.height) * 1.5;
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
-      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
-        rgba(0,0,0,0) ${r}px,
-        rgba(0,0,0,0.5) ${r + fade}px)`;
-      gear.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
-    } else if (step === 4 && card) {
-      const fade = 60; // narrower fade for smaller spotlight
-      const rect = card.getBoundingClientRect();
-      const r = Math.hypot(rect.width, rect.height) / 2;
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
-      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
-        rgba(0,0,0,0) ${r}px,
-        rgba(0,0,0,0.5) ${r + fade}px)`;
-      card.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
-    } else if (panel) {
-      const fade = 120;
-      const rect = panel.getBoundingClientRect();
-      const x = rect.left + rect.width / 2;
-      const y = rect.top + rect.height / 2;
-      const r = Math.hypot(rect.width, rect.height) / 2 + 40;
-      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
-        rgba(0,0,0,0) ${r}px,
-        rgba(0,0,0,0.4) ${r + fade}px)`;
-    }
+      if (step === 3 && gearEl) {
+        const fade = 120; // width of the gradient fade
+        const rect = gearEl.getBoundingClientRect();
+        const r = Math.max(rect.width, rect.height) * 1.5;
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        overlayEl.style.background = `radial-gradient(circle at ${x}px ${y}px,
+          rgba(0,0,0,0) ${r}px,
+          rgba(0,0,0,0.5) ${r + fade}px)`;
+        gearEl.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
+      } else if (step === 4 && cardEl) {
+        const fade = 60; // narrower fade for smaller spotlight
+        const rect = cardEl.getBoundingClientRect();
+        const r = Math.hypot(rect.width, rect.height) / 2;
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        overlayEl.style.background = `radial-gradient(circle at ${x}px ${y}px,
+          rgba(0,0,0,0) ${r}px,
+          rgba(0,0,0,0.5) ${r + fade}px)`;
+        cardEl.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
+      } else {
+        const fade = 120;
+        const rect = panel.getBoundingClientRect();
+        const x = rect.left + rect.width / 2;
+        const y = rect.top + rect.height / 2;
+        const r = Math.hypot(rect.width, rect.height) / 2 + 40;
+        overlayEl.style.background = `radial-gradient(circle at ${x}px ${y}px,
+          rgba(0,0,0,0) ${r}px,
+          rgba(0,0,0,0.4) ${r + fade}px)`;
+      }
+    };
 
+    frame = requestAnimationFrame(updateHighlight);
     return () => {
-      gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
-      card?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
-      if (overlay) {
-        overlay.style.background = "";
+      cancelAnimationFrame(frame);
+      gearEl?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+      cardEl?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+      if (overlayEl) {
+        overlayEl.style.background = "";
       }
     };
   }, [step, isOpen, settingsButtonRef, profileCardRef]);

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -46,6 +46,12 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
   const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    if (!isOpen) {
+      setStep(0);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
     const gear = settingsButtonRef.current;
     const card = profileCardRef.current;
     const overlay = overlayRef.current;
@@ -103,19 +109,18 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
             opacity: 0,
           },
         ],
-        { duration: 300, easing: "ease-in-out" }
+        { duration: 300, easing: "ease-in-out", fill: "forwards" }
       );
       overlay.animate([{ opacity: 1 }, { opacity: 0 }], {
         duration: 300,
         easing: "ease-in-out",
+        fill: "forwards",
       });
       anim.onfinish = () => {
         onClose();
-        setStep(0);
       };
     } else {
       onClose();
-      setStep(0);
     }
   };
 

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -5,12 +5,13 @@ interface FirstTimeExperienceProps {
   isOpen: boolean;
   onClose: () => void;
   settingsButtonRef: React.RefObject<HTMLButtonElement>;
+  profileCardRef: React.RefObject<HTMLDivElement>;
 }
 
 const slides = [
   {
     title: "Welcome!",
-    body: "Let's take a quick tour so you know where everything lives.",
+    body: "Virginia SOL Explorer helps you see which skills your child has mastered. Let's take a quick tour.",
   },
   {
     title: "Your Info Stays Here",
@@ -25,6 +26,10 @@ const slides = [
     body: "Click the gear in the top corner to add a student or edit a name.",
   },
   {
+    title: "Track progress at a glance",
+    body: "This box fills up as your student works through skills and standards.",
+  },
+  {
     title: "Share profiles",
     body: "Use Export to download a backup file and Import to load it on another computer.",
   },
@@ -34,6 +39,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
   isOpen,
   onClose,
   settingsButtonRef,
+  profileCardRef,
 }) => {
   const [step, setStep] = useState(0);
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -41,16 +47,40 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
 
   useEffect(() => {
     const gear = settingsButtonRef.current;
-    if (!gear) return;
-    if (step === 3) {
-      gear.classList.add("ring-4", "ring-orange-400", "animate-pulse", "z-30");
-    } else {
-      gear.classList.remove("ring-4", "ring-orange-400", "animate-pulse", "z-30");
+    const card = profileCardRef.current;
+    const overlay = overlayRef.current;
+    if (!overlay) return;
+
+    // Reset any previous highlighting
+    overlay.style.clipPath = "";
+    overlay.style.background = "";
+    gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+    card?.classList.remove("ring-4", "ring-white", "z-30");
+
+    if (step === 3 && gear) {
+      const rect = gear.getBoundingClientRect();
+      const radius = Math.max(rect.width, rect.height) * 1.5;
+      overlay.style.background = "rgba(0,0,0,0.6)";
+      overlay.style.clipPath = `circle(${radius}px at ${rect.left + rect.width / 2}px ${rect.top + rect.height / 2}px)`;
+      gear.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
+    } else if (step === 4 && card) {
+      const rect = card.getBoundingClientRect();
+      const right = window.innerWidth - (rect.left + rect.width);
+      const bottom = window.innerHeight - (rect.top + rect.height);
+      overlay.style.background = "rgba(0,0,0,0.6)";
+      overlay.style.clipPath = `inset(${rect.top}px ${right}px ${bottom}px ${rect.left}px round 12px)`;
+      card.classList.add("ring-4", "ring-white", "z-30");
     }
+
     return () => {
-      gear.classList.remove("ring-4", "ring-orange-400", "animate-pulse", "z-30");
+      gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+      card?.classList.remove("ring-4", "ring-white", "z-30");
+      if (overlay) {
+        overlay.style.clipPath = "";
+        overlay.style.background = "";
+      }
     };
-  }, [step, settingsButtonRef]);
+  }, [step, settingsButtonRef, profileCardRef]);
 
   const next = () => setStep((s) => Math.min(s + 1, slides.length - 1));
   const prev = () => setStep((s) => Math.max(s - 1, 0));

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -55,6 +55,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
     const gear = settingsButtonRef.current;
     const card = profileCardRef.current;
     const overlay = overlayRef.current;
+    const panel = panelRef.current;
     if (!overlay) return;
 
     // Reset any previous highlighting
@@ -66,16 +67,23 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
     if (step === 3 && gear) {
       const rect = gear.getBoundingClientRect();
       const radius = Math.max(rect.width, rect.height) * 1.5;
-      overlay.style.background = "rgba(0,0,0,0.6)";
+      overlay.style.background = "rgba(0,0,0,0.5)";
       overlay.style.clipPath = `circle(${radius}px at ${rect.left + rect.width / 2}px ${rect.top + rect.height / 2}px)`;
       gear.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
     } else if (step === 4 && card) {
       const rect = card.getBoundingClientRect();
       const right = window.innerWidth - (rect.left + rect.width);
       const bottom = window.innerHeight - (rect.top + rect.height);
-      overlay.style.background = "rgba(0,0,0,0.6)";
+      overlay.style.background = "rgba(0,0,0,0.5)";
       overlay.style.clipPath = `inset(${rect.top}px ${right}px ${bottom}px ${rect.left}px round 12px)`;
       card.classList.add("ring-4", "ring-white", "z-30");
+    } else if (panel) {
+      const rect = panel.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const radius = Math.hypot(rect.width, rect.height) / 2 + 40;
+      overlay.style.background = "rgba(0,0,0,0.4)";
+      overlay.style.clipPath = `circle(${radius}px at ${centerX}px ${centerY}px)`;
     }
 
     return () => {
@@ -133,7 +141,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
           enterFrom="opacity-0"
           enterTo="opacity-100"
         >
-          <div ref={overlayRef} className="fixed inset-0 bg-amber-50/60" />
+          <div ref={overlayRef} className="fixed inset-0" />
         </Transition.Child>
 
         <div className="fixed inset-0 flex items-center justify-center p-4">

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -1,0 +1,121 @@
+import React, { Fragment, useState } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+
+interface FirstTimeExperienceProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const slides = [
+  {
+    title: "Your Info Stays Here",
+    body: "This app never connects to the internet. Everything you see or type stays on this computer.",
+  },
+  {
+    title: "What \"on-device\" means",
+    body: "On-device means your student's progress is saved only inside your browser. It isn't sent anywhere else.",
+  },
+  {
+    title: "Manage students",
+    body: "Click the gear in the top corner to add a student or edit a name.",
+  },
+  {
+    title: "Share profiles",
+    body: "Use Export to download a backup file and Import to load it on another computer.",
+  },
+];
+
+const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const [step, setStep] = useState(0);
+
+  const next = () => setStep((s) => Math.min(s + 1, slides.length - 1));
+  const prev = () => setStep((s) => Math.max(s - 1, 0));
+  const finish = () => {
+    onClose();
+    setStep(0);
+  };
+
+  return (
+    <Transition.Root show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-20" onClose={finish}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black bg-opacity-25" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 flex items-center justify-center p-4">
+          <Transition.Child
+            as={Fragment}
+            enter="ease-out duration-300"
+            enterFrom="opacity-0 scale-95"
+            enterTo="opacity-100 scale-100"
+            leave="ease-in duration-200"
+            leaveFrom="opacity-100 scale-100"
+            leaveTo="opacity-0 scale-95"
+          >
+            <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-lg bg-white p-6 text-left shadow-xl transition-all">
+              <div className="relative min-h-[150px]">
+                {slides.map((slide, idx) => (
+                  <Transition
+                    key={idx}
+                    show={idx === step}
+                    as={Fragment}
+                    enter="transition-opacity transform duration-300"
+                    enterFrom="opacity-0 translate-x-4"
+                    enterTo="opacity-100 translate-x-0"
+                    leave="transition-opacity transform duration-300 absolute inset-0"
+                    leaveFrom="opacity-100 translate-x-0"
+                    leaveTo="opacity-0 -translate-x-4"
+                  >
+                    <div className="absolute inset-0">
+                      <Dialog.Title className="text-lg font-semibold mb-2">
+                        {slide.title}
+                      </Dialog.Title>
+                      <p className="text-sm text-gray-700">{slide.body}</p>
+                    </div>
+                  </Transition>
+                ))}
+              </div>
+              <div className="mt-6 flex justify-between">
+                <button
+                  className="px-3 py-1 text-sm rounded bg-gray-100 text-gray-700 disabled:opacity-40 cursor-pointer"
+                  onClick={prev}
+                  disabled={step === 0}
+                >
+                  Back
+                </button>
+                {step === slides.length - 1 ? (
+                  <button
+                    className="px-3 py-1 text-sm rounded bg-blue-600 text-white cursor-pointer"
+                    onClick={finish}
+                  >
+                    Let's Start
+                  </button>
+                ) : (
+                  <button
+                    className="px-3 py-1 text-sm rounded bg-blue-600 text-white cursor-pointer"
+                    onClick={next}
+                  >
+                    Next
+                  </button>
+                )}
+              </div>
+            </Dialog.Panel>
+          </Transition.Child>
+        </div>
+      </Dialog>
+    </Transition.Root>
+  );
+};
+
+export default FirstTimeExperience;

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -59,42 +59,48 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
     if (!overlay) return;
 
     // Reset any previous highlighting
-    overlay.style.clipPath = "";
     overlay.style.background = "";
     gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
-    card?.classList.remove("ring-4", "ring-white", "z-30");
+    card?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
+
+    const fade = 120; // width of the gradient fade
 
     if (step === 3 && gear) {
       const rect = gear.getBoundingClientRect();
-      const radius = Math.max(rect.width, rect.height) * 1.5;
-      overlay.style.background = "rgba(0,0,0,0.5)";
-      overlay.style.clipPath = `circle(${radius}px at ${rect.left + rect.width / 2}px ${rect.top + rect.height / 2}px)`;
+      const r = Math.max(rect.width, rect.height) * 1.5;
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
+        rgba(0,0,0,0) ${r}px,
+        rgba(0,0,0,0.5) ${r + fade}px)`;
       gear.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
     } else if (step === 4 && card) {
       const rect = card.getBoundingClientRect();
-      const right = window.innerWidth - (rect.left + rect.width);
-      const bottom = window.innerHeight - (rect.top + rect.height);
-      overlay.style.background = "rgba(0,0,0,0.5)";
-      overlay.style.clipPath = `inset(${rect.top}px ${right}px ${bottom}px ${rect.left}px round 12px)`;
-      card.classList.add("ring-4", "ring-white", "z-30");
+      const r = Math.hypot(rect.width, rect.height) / 2;
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
+        rgba(0,0,0,0) ${r}px,
+        rgba(0,0,0,0.5) ${r + fade}px)`;
+      card.classList.add("ring-4", "ring-white", "animate-pulse", "z-30");
     } else if (panel) {
       const rect = panel.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const centerY = rect.top + rect.height / 2;
-      const radius = Math.hypot(rect.width, rect.height) / 2 + 40;
-      overlay.style.background = "rgba(0,0,0,0.4)";
-      overlay.style.clipPath = `circle(${radius}px at ${centerX}px ${centerY}px)`;
+      const x = rect.left + rect.width / 2;
+      const y = rect.top + rect.height / 2;
+      const r = Math.hypot(rect.width, rect.height) / 2 + 40;
+      overlay.style.background = `radial-gradient(circle at ${x}px ${y}px,
+        rgba(0,0,0,0) ${r}px,
+        rgba(0,0,0,0.4) ${r + fade}px)`;
     }
 
     return () => {
       gear?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
-      card?.classList.remove("ring-4", "ring-white", "z-30");
+      card?.classList.remove("ring-4", "ring-white", "animate-pulse", "z-30");
       if (overlay) {
-        overlay.style.clipPath = "";
         overlay.style.background = "";
       }
     };
-  }, [step, settingsButtonRef, profileCardRef]);
+  }, [step, isOpen, settingsButtonRef, profileCardRef]);
 
   const next = () => setStep((s) => Math.min(s + 1, slides.length - 1));
   const prev = () => setStep((s) => Math.max(s - 1, 0));
@@ -141,7 +147,7 @@ const FirstTimeExperience: React.FC<FirstTimeExperienceProps> = ({
           enterFrom="opacity-0"
           enterTo="opacity-100"
         >
-          <div ref={overlayRef} className="fixed inset-0" />
+          <div ref={overlayRef} className="pointer-events-none fixed inset-0" />
         </Transition.Child>
 
         <div className="fixed inset-0 flex items-center justify-center p-4">

--- a/src/components/ProfileSummaryCard.tsx
+++ b/src/components/ProfileSummaryCard.tsx
@@ -10,10 +10,8 @@ interface ProfileSummaryCardProps {
   filteredStandards: SubjectStandard[]; // These are subject standards
 }
 
-const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
-  profileId,
-  filteredStandards,
-}) => {
+const ProfileSummaryCard = React.forwardRef<HTMLDivElement, ProfileSummaryCardProps>(
+  ({ profileId, filteredStandards }, ref) => {
   const { selectedProfileId } = useProfile();
   const actualProfileId = profileId || selectedProfileId;
 
@@ -77,7 +75,10 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-lg shadow-md overflow-hidden lg:h-[82px] mb-2">
+    <div
+      ref={ref}
+      className="bg-white rounded-lg shadow-md overflow-hidden lg:h-[82px] mb-2"
+    >
       <div className="flex h-full">
         {/* Left section - Avatar */}
         <div className="bg-gradient-to-b from-white to-gray-100 h-full w-[82px] flex items-center justify-center">
@@ -183,6 +184,6 @@ const ProfileSummaryCard: React.FC<ProfileSummaryCardProps> = ({
       </div>
     </div>
   );
-};
+});
 
 export default ProfileSummaryCard;

--- a/src/components/SettingsFlyout.tsx
+++ b/src/components/SettingsFlyout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, Fragment, useRef } from "react";
+import React, { useState, Fragment } from "react";
 import {
   Transition,
   Menu,
@@ -15,17 +15,18 @@ interface SettingsFlyoutProps {
   hideCompleted: boolean;
   setHideCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   openIntro: () => void;
+  gearRef?: React.RefObject<HTMLButtonElement>;
 }
 
 const SettingsFlyout: React.FC<SettingsFlyoutProps> = ({
   hideCompleted,
   setHideCompleted,
   openIntro,
+  gearRef,
 }) => {
   const [modalContent, setModalContent] = useState<
     "import" | "export" | "profiles" | null
   >(null);
-  const buttonRef = useRef(null);
 
   const openModal = (content: "import" | "export" | "profiles") => {
     setModalContent(content);
@@ -40,7 +41,7 @@ const SettingsFlyout: React.FC<SettingsFlyoutProps> = ({
       <Menu as="div" className="relative inline-block text-left">
         <div>
           <Menu.Button
-            ref={buttonRef}
+            ref={gearRef}
             className="p-1 lg:p2 rounded-full bg-gray-200 hover:bg-gray-300 focus:outline-none cursor-pointer"
           >
             <CogIcon className="h-6 w-6 text-gray-700" />

--- a/src/components/SettingsFlyout.tsx
+++ b/src/components/SettingsFlyout.tsx
@@ -14,11 +14,13 @@ import ImportDataModal from "./ImportDataModal";
 interface SettingsFlyoutProps {
   hideCompleted: boolean;
   setHideCompleted: React.Dispatch<React.SetStateAction<boolean>>;
+  openIntro: () => void;
 }
 
 const SettingsFlyout: React.FC<SettingsFlyoutProps> = ({
   hideCompleted,
   setHideCompleted,
+  openIntro,
 }) => {
   const [modalContent, setModalContent] = useState<
     "import" | "export" | "profiles" | null
@@ -120,6 +122,18 @@ const SettingsFlyout: React.FC<SettingsFlyoutProps> = ({
                     onClick={() => openModal("profiles")}
                   >
                     Profiles
+                  </button>
+                )}
+              </Menu.Item>
+              <Menu.Item>
+                {({ active }) => (
+                  <button
+                    className={`${
+                      active ? "bg-gray-100 text-gray-900" : "text-gray-700"
+                    } group flex w-full items-center rounded-md px-2 py-2 text-sm cursor-pointer`}
+                    onClick={openIntro}
+                  >
+                    Show Tutorial
                   </button>
                 )}
               </Menu.Item>


### PR DESCRIPTION
## Summary
- introduce tutorial modal explaining app security, profiles, and sharing
- remember dismissal in a cookie and expose a settings menu action to reopen
- document first-time tour in README

## Testing
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a7dc8a9c7c832caa551243895fe922