### PR TITLE
refactor: use IntersectionObserver for active section

### DIFF
--- a/src/TwoPaneSubjectStandardDisplay.tsx
+++ b/src/TwoPaneSubjectStandardDisplay.tsx
@@ -12,25 +12,25 @@ const TwoPaneSubjectStandardDisplay: React.FC<{
   const [activeSection, setActiveSection] = useState("");
 
   useEffect(() => {
-    const handleScroll = () => {
-      const cards = document.querySelectorAll(".subject-standard-card");
-      for (let i = cards.length - 1; i >= 0; i--) {
-        const card = cards[i];
-        if (card.getBoundingClientRect().top <= 200) {
-          setActiveSection(card.id);
-          break;
-        }
-      }
-    };
+    const container = document.getElementById(STANDARDS_DISPLAY_ID);
+    if (!container) return;
 
-    document
-      .getElementById(STANDARDS_DISPLAY_ID)!
-      .addEventListener("scroll", handleScroll);
-    return () =>
-      document
-        .getElementById(STANDARDS_DISPLAY_ID)!
-        .removeEventListener("scroll", handleScroll);
-  }, []);
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveSection(entry.target.id);
+          }
+        });
+      },
+      { root: container, threshold: 0.1 }
+    );
+
+    const cards = container.querySelectorAll(".subject-standard-card");
+    cards.forEach((card) => observer.observe(card));
+
+    return () => observer.disconnect();
+  }, [subjectStandards]);
 
   return (
     <div className="flex overflow-y-scroll bg-gray-100">

--- a/src/components/FirstTimeExperience.tsx
+++ b/src/components/FirstTimeExperience.tsx
@@ -10,8 +10,8 @@ import { Dialog, Transition } from "@headlessui/react";
 interface FirstTimeExperienceProps {
   isOpen: boolean;
   onClose: () => void;
-  settingsButtonRef: React.RefObject<HTMLButtonElement>;
-  profileCardRef: React.RefObject<HTMLDivElement>;
+  settingsButtonRef: React.RefObject<HTMLButtonElement | null>;
+  profileCardRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const slides = [

--- a/src/components/SettingsFlyout.tsx
+++ b/src/components/SettingsFlyout.tsx
@@ -15,7 +15,7 @@ interface SettingsFlyoutProps {
   hideCompleted: boolean;
   setHideCompleted: React.Dispatch<React.SetStateAction<boolean>>;
   openIntro: () => void;
-  gearRef?: React.RefObject<HTMLButtonElement>;
+  gearRef?: React.RefObject<HTMLButtonElement | null>;
 }
 
 const SettingsFlyout: React.FC<SettingsFlyoutProps> = ({


### PR DESCRIPTION
## Summary
- replace manual scroll listener with IntersectionObserver for standard cards
- update active section when cards become visible
- allow ref props to accept null to satisfy type checks

## Testing
- `bun run lint`
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7f6fc6c98832cbb665ba6af53b05d